### PR TITLE
Fixed missing project_id issue

### DIFF
--- a/app/views/hooks/text_blocks/_view_issues_edit_notes_bottom.html.erb
+++ b/app/views/hooks/text_blocks/_view_issues_edit_notes_bottom.html.erb
@@ -1,4 +1,5 @@
 <% if User.current.allowed_to?(:view_text_blocks, @project) %>
   <%= select_tag :text_block, text_block_options(@issue), id: 'textblock-select', style: 'display:none; border: 1px solid #e0e2e3; background: #f6f6f6; height: 24px; color: #3d454c; vertical-align: bottom; margin-left: 6px; margin-botton: 0;' %>
   <%= javascript_include_tag 'text_blocks', plugin: 'redmine_text_blocks' %>
+  <%= hidden_field_tag :text_block_project_id, @project.id %>
 <% end %>

--- a/assets/javascripts/text_blocks.js
+++ b/assets/javascripts/text_blocks.js
@@ -35,9 +35,16 @@ var TextBlocks = {
   },
 
   reload: function(e){
+    debugger
+    var projectId = null
+    if ($("#issue_project_id").size() > 0) {
+      projectId = $("#issue_project_id").val()
+    } else {
+      projectId = $("#text_block_project_id").val()
+    }
     $("#textblock-select option:gt(0)").remove();
     $.ajax({
-      url: "/text_blocks_by_status/"+$("#issue_status_id").val()+"/"+$("#issue_project_id").val(),
+      url: "/text_blocks_by_status/" + $("#issue_status_id").val() + "/" + projectId,
       method: "GET",
       success: function(data){
         data.forEach(function(tb){


### PR DESCRIPTION
Fixes #4.

Changes proposed in this pull request:
- Add `text_block_project_id` as hidden input tag ~~when~~ to support available project is only one case.

@gtt-project/maintainer
