### PR TITLE
Deleted debugger line in text_blocks.js

### DIFF
--- a/assets/javascripts/text_blocks.js
+++ b/assets/javascripts/text_blocks.js
@@ -35,7 +35,6 @@ var TextBlocks = {
   },
 
   reload: function(e){
-    debugger
     var projectId = null
     if ($("#issue_project_id").size() > 0) {
       projectId = $("#issue_project_id").val()


### PR DESCRIPTION
Changes proposed in this pull request:
- Delete unnecessary `debugger` line in `text_blocks.js`.

@gtt-project/maintainer
