### PR TITLE
Fixed test error on Redmine5.0 + Ruby3.1 environment

### DIFF
--- a/lib/redmine_text_blocks/save_text_block.rb
+++ b/lib/redmine_text_blocks/save_text_block.rb
@@ -3,8 +3,8 @@ module RedmineTextBlocks
 
     Result = ImmutableStruct.new :text_block_saved?, :text_block
 
-    def self.call(*_)
-      new(*_).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     def initialize(params, text_block: TextBlock.new,


### PR DESCRIPTION
Fixes #24.

Changes proposed in this pull request:
- Fixed test error on Redmine5.0 + Ruby3.1 environment
- Added `**kwargs` to `call` method as keyword arguments

@gtt-project/maintainer
