### PR TITLE
Sortable text_blocks (templates)

### DIFF
--- a/app/controllers/text_blocks_controller.rb
+++ b/app/controllers/text_blocks_controller.rb
@@ -40,9 +40,20 @@ class TextBlocksController < ApplicationController
     r = RedmineTextBlocks::SaveTextBlock.(text_block_params,
                                           text_block: @text_block)
     if r.text_block_saved?
-      redirect_to index_path
+      respond_to do |format|
+        format.html {
+          flash[:notice] = l(:notice_successful_update)
+          redirect_to index_path
+        }
+        format.js { head 200 }
+      end
     else
-      render 'edit'
+      respond_to do |format|
+        format.html {
+          render 'edit'
+        }
+        format.js { head 422 }
+      end
     end
   end
 
@@ -69,7 +80,7 @@ class TextBlocksController < ApplicationController
   end
 
   def text_block_params
-    params[:text_block].permit :name, :text, :issue_status_ids => []
+    params[:text_block].permit :name, :text, :issue_status_ids, :position
   end
 
   def find_text_block
@@ -83,7 +94,7 @@ class TextBlocksController < ApplicationController
   end
 
   def text_block_scope
-    TextBlock.order(name: :asc).where(project_id: @project&.id)
+    TextBlock.where(project_id: @project&.id).sorted
   end
 
   def get_issue_statuses

--- a/app/controllers/text_blocks_controller.rb
+++ b/app/controllers/text_blocks_controller.rb
@@ -102,6 +102,6 @@ class TextBlocksController < ApplicationController
   end
 
   def get_blocks_by_status(status_id)
-    IssueStatus.find(status_id).text_blocks.blank? ? text_block_scope : IssueStatus.find(status_id).text_blocks.where(project_id: [nil, @project&.id])
+    IssueStatus.find(status_id).text_blocks.blank? ? text_block_scope : IssueStatus.find(status_id).text_blocks.where(project_id: [nil, @project&.id]).sorted
   end
 end

--- a/app/controllers/text_blocks_controller.rb
+++ b/app/controllers/text_blocks_controller.rb
@@ -102,7 +102,7 @@ class TextBlocksController < ApplicationController
   end
 
   def get_blocks_by_status(status_id)
-    if IssueStatus.find(status_id).text_blocks.blank
+    if IssueStatus.find(status_id).text_blocks.blank?
       text_block_scope
     else
       IssueStatus.find(status_id).text_blocks.

--- a/app/controllers/text_blocks_controller.rb
+++ b/app/controllers/text_blocks_controller.rb
@@ -80,7 +80,7 @@ class TextBlocksController < ApplicationController
   end
 
   def text_block_params
-    params[:text_block].permit :name, :text, :issue_status_ids, :position
+    params[:text_block].permit :name, :text, :position, :issue_status_ids => []
   end
 
   def find_text_block
@@ -102,6 +102,11 @@ class TextBlocksController < ApplicationController
   end
 
   def get_blocks_by_status(status_id)
-    IssueStatus.find(status_id).text_blocks.blank? ? text_block_scope : IssueStatus.find(status_id).text_blocks.where(project_id: [nil, @project&.id]).sorted
+    if IssueStatus.find(status_id).text_blocks.blank
+      text_block_scope
+    else
+      IssueStatus.find(status_id).text_blocks.
+        where(project_id: [nil, @project&.id]).sorted
+    end
   end
 end

--- a/app/helpers/text_blocks_helper.rb
+++ b/app/helpers/text_blocks_helper.rb
@@ -6,13 +6,13 @@ module TextBlocksHelper
     end
     status_textblocks = IssueStatus.find(issue.status_id).text_blocks if issue
     if !status_textblocks.blank?
-      tags += status_textblocks.where(project_id: [nil, @project.id]).map{|tb|
+      tags += status_textblocks.where(project_id: [nil, @project.id]).sorted.map{|tb|
         content_tag :option, value: tb.text do
           tb.name
         end
       }
     else
-      tags += TextBlock.where(project_id: [nil, @project.id]).to_a.map{|tb|
+      tags += TextBlock.where(project_id: [nil, @project.id]).sorted.to_a.map{|tb|
         content_tag :option, value: tb.text do
           tb.name
         end

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -8,7 +8,7 @@ class TextBlock < ActiveRecord::Base
   validates_numericality_of :position, :only_integer => true
   before_create :set_position
 
-  scope :sorted, ->{ order :position }
+  scope :sorted, ->{ order('project_id IS NOT NULL, project_id ASC, position ASC') }
 
   private
 
@@ -29,10 +29,8 @@ class TextBlock < ActiveRecord::Base
       max = self.class.where(:project_id => project_id).maximum(:position) || 0
       self.position = max + 1
     else
-      binding.pry
       max = self.class.where(:project_id => nil).maximum(:position) || 0
       self.position = max + 1
     end
   end
-
 end

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -8,7 +8,7 @@ class TextBlock < ActiveRecord::Base
   validates_numericality_of :position, :only_integer => true
   before_create :set_position
 
-  scope :sorted, ->{ order('project_id IS NOT NULL, project_id ASC, position ASC') }
+  scope :sorted, ->{ order(Arel.sql('project_id IS NOT NULL, project_id ASC, position ASC')) }
 
   private
 

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -5,8 +5,6 @@ class TextBlock < ActiveRecord::Base
 
   validates :name, presence: true
   validate :name_uniqueness
-  validates_numericality_of :position, :only_integer => true
-  before_create :set_position
 
   scope :sorted, ->{ order(Arel.sql('project_id IS NOT NULL, project_id ASC, position ASC')) }
 
@@ -21,16 +19,6 @@ class TextBlock < ActiveRecord::Base
 
     if scope.any?
       errors.add :name, I18n.t('model.text_block.name_uniqueness')
-    end
-  end
-
-  def set_position
-    if project_id.present?
-      max = self.class.where(:project_id => project_id).maximum(:position) || 0
-      self.position = max + 1
-    else
-      max = self.class.where(:project_id => nil).maximum(:position) || 0
-      self.position = max + 1
     end
   end
 end

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -5,6 +5,9 @@ class TextBlock < ActiveRecord::Base
 
   validates :name, presence: true
   validate :name_uniqueness
+  validates_numericality_of :position, :only_integer => true
+  before_create :set_position
+
   scope :sorted, ->{ order :position }
 
   private
@@ -18,6 +21,17 @@ class TextBlock < ActiveRecord::Base
 
     if scope.any?
       errors.add :name, I18n.t('model.text_block.name_uniqueness')
+    end
+  end
+
+  def set_position
+    if project_id.present?
+      max = self.class.where(:project_id => project_id).maximum(:position) || 0
+      self.position = max + 1
+    else
+      binding.pry
+      max = self.class.where(:project_id => nil).maximum(:position) || 0
+      self.position = max + 1
     end
   end
 

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -1,10 +1,11 @@
 class TextBlock < ActiveRecord::Base
   belongs_to :project
   has_and_belongs_to_many :issue_statuses
+  acts_as_positioned :scope => [:project_id]
 
   validates :name, presence: true
   validate :name_uniqueness
-
+  scope :sorted, ->{ order :position }
 
   private
 

--- a/app/views/projects/settings/_text_blocks.html.erb
+++ b/app/views/projects/settings/_text_blocks.html.erb
@@ -2,5 +2,5 @@
   <%= link_to l(:label_text_block_new), new_project_text_block_path(@project), class: 'icon icon-add' %>
 </p>
 
-<%= render partial: 'text_blocks/list', locals: { text_blocks: TextBlock.where(project_id: @project.id) } %>
+<%= render partial: 'text_blocks/list', locals: { text_blocks: TextBlock.where(project_id: @project.id).sorted } %>
 

--- a/app/views/text_blocks/_list.html.erb
+++ b/app/views/text_blocks/_list.html.erb
@@ -32,5 +32,13 @@
         $("table.list.textblocks tbody td.text div").trigger('update.dot');
       }
     });
+    $(function() {
+      $("table.textblocks tbody").positionedItems({
+        scroll: false,
+        sort: function (event, ui) {
+          ui.helper.css({'top': ui.position.top + $(window).scrollTop() + 'px'});
+        },
+      });
+    });
   <% end %>
 <% end %>

--- a/app/views/text_blocks/_list.html.erb
+++ b/app/views/text_blocks/_list.html.erb
@@ -33,12 +33,7 @@
       }
     });
     $(function() {
-      $("table.textblocks tbody").positionedItems({
-        scroll: false,
-        sort: function (event, ui) {
-          ui.helper.css({'top': ui.position.top + $(window).scrollTop() + 'px'});
-        },
-      });
+      $("table.textblocks tbody").positionedItems();
     });
   <% end %>
 <% end %>

--- a/app/views/text_blocks/_text_block.html.erb
+++ b/app/views/text_blocks/_text_block.html.erb
@@ -6,5 +6,8 @@
       <%= textilizable s %>
     <% end %>
   </div></td>
-  <td><%= delete_link(text_block.project ? project_text_block_path(text_block.project, text_block) : text_block_path(text_block)) %>
+  <td class="buttons">
+    <%= reorder_handle(text_block, url: text_block.project ? project_text_block_path(text_block.project, text_block) : text_block_path(text_block)) %>
+    <%= delete_link(text_block.project ? project_text_block_path(text_block.project, text_block) : text_block_path(text_block)) %>
+  </td>
 </tr>

--- a/db/migrate/20230325132825_add_position_to_text_blocks.rb
+++ b/db/migrate/20230325132825_add_position_to_text_blocks.rb
@@ -1,0 +1,5 @@
+class AddPositionToTextBlocks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :text_blocks, :position, :integer
+  end
+end

--- a/db/migrate/20230325132825_add_position_to_text_blocks.rb
+++ b/db/migrate/20230325132825_add_position_to_text_blocks.rb
@@ -1,6 +1,6 @@
 class AddPositionToTextBlocks < ActiveRecord::Migration[5.2]
   def change
-    add_column :text_blocks, :position, :integer, :default => 1
+    add_column :text_blocks, :position, :integer
     # # After executing "rake redmine:plugins:migrate", execute the following on "rails console", if keeping the existing positions is important:
     # res = TextBlock.connection.select_all("SELECT id, name, project_id, row_number() over(PARTITION by project_id) AS position FROM #{TextBlock.table_name}")
     # res.rows.each{|row| TextBlock.connection.execute("UPDATE #{TextBlock.table_name} SET position=#{row[3]} WHERE id=#{row[0]}")}

--- a/db/migrate/20230325132825_add_position_to_text_blocks.rb
+++ b/db/migrate/20230325132825_add_position_to_text_blocks.rb
@@ -1,5 +1,5 @@
 class AddPositionToTextBlocks < ActiveRecord::Migration[5.2]
   def change
-    add_column :text_blocks, :position, :integer
+    add_column :text_blocks, :position, :integer, :default => 1
   end
 end

--- a/db/migrate/20230325132825_add_position_to_text_blocks.rb
+++ b/db/migrate/20230325132825_add_position_to_text_blocks.rb
@@ -1,5 +1,8 @@
 class AddPositionToTextBlocks < ActiveRecord::Migration[5.2]
   def change
     add_column :text_blocks, :position, :integer, :default => 1
+    # # After executing "rake redmine:plugins:migrate", execute the following on "rails console", if keeping the existing positions is important:
+    # res = TextBlock.connection.select_all("SELECT id, name, project_id, row_number() over(PARTITION by project_id) AS position FROM #{TextBlock.table_name}")
+    # res.rows.each{|row| TextBlock.connection.execute("UPDATE #{TextBlock.table_name} SET position=#{row[3]} WHERE id=#{row[0]}")}
   end
 end

--- a/test/integration/text_blocks_admin_test.rb
+++ b/test/integration/text_blocks_admin_test.rb
@@ -31,6 +31,7 @@ class TextBlocksAdminTest < Redmine::IntegrationTest
 
     assert b = TextBlock.find_by_name('test')
     assert_equal 'lorem ipsum', b.text
+    assert_equal 1, b.position
 
     get "/text_blocks/#{b.id}/edit"
     assert_response :success
@@ -39,6 +40,17 @@ class TextBlocksAdminTest < Redmine::IntegrationTest
     b.reload
     assert_equal 'lorem ipsum', b.text
     assert_equal 'new', b.name
+
+    assert_difference 'TextBlock.count' do
+      post '/text_blocks', params: { text_block: { name: 'test2', text: 'lorem ipsum2'}}
+    end
+    assert_redirected_to '/text_blocks'
+
+    follow_redirect!
+
+    assert b = TextBlock.find_by_name('test2')
+    assert_equal 'lorem ipsum2', b.text
+    assert_equal 2, b.position
 
     assert_difference 'TextBlock.count', -1 do
       delete "/text_blocks/#{b.id}"

--- a/test/integration/text_blocks_admin_test.rb
+++ b/test/integration/text_blocks_admin_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 class TextBlocksAdminTest < Redmine::IntegrationTest
-  fixtures :users, :email_addresses, :user_preferences
+  fixtures :users, :email_addresses, :user_preferences, :issue_statuses
 
   def setup
     super
@@ -23,7 +23,9 @@ class TextBlocksAdminTest < Redmine::IntegrationTest
     assert_response :success
 
     assert_difference 'TextBlock.count' do
-      post '/text_blocks', params: { text_block: { name: 'test', text: 'lorem ipsum'}}
+      post '/text_blocks', params: {
+        text_block: { name: 'test', text: 'lorem ipsum', issue_status_ids: [1, 2] }
+      }
     end
     assert_redirected_to '/text_blocks'
 
@@ -31,6 +33,7 @@ class TextBlocksAdminTest < Redmine::IntegrationTest
 
     assert b = TextBlock.find_by_name('test')
     assert_equal 'lorem ipsum', b.text
+    assert_equal [1, 2], b.issue_statuses.map(&:id).sort
     assert_equal 1, b.position
 
     get "/text_blocks/#{b.id}/edit"
@@ -42,7 +45,9 @@ class TextBlocksAdminTest < Redmine::IntegrationTest
     assert_equal 'new', b.name
 
     assert_difference 'TextBlock.count' do
-      post '/text_blocks', params: { text_block: { name: 'test2', text: 'lorem ipsum2'}}
+      post '/text_blocks', params: {
+        text_block: { name: 'test2', text: 'lorem ipsum2', issue_status_ids: [1, 2] }
+      }
     end
     assert_redirected_to '/text_blocks'
 
@@ -50,6 +55,7 @@ class TextBlocksAdminTest < Redmine::IntegrationTest
 
     assert b = TextBlock.find_by_name('test2')
     assert_equal 'lorem ipsum2', b.text
+    assert_equal [1, 2], b.issue_statuses.map(&:id).sort
     assert_equal 2, b.position
 
     assert_difference 'TextBlock.count', -1 do

--- a/test/integration/text_blocks_project_test.rb
+++ b/test/integration/text_blocks_project_test.rb
@@ -45,6 +45,7 @@ class TextBlocksProjectTest < Redmine::IntegrationTest
 
     assert b = TextBlock.find_by_name('test')
     assert_equal 'lorem ipsum', b.text
+    assert_equal 1, b.position
 
     get "/projects/ecookbook/text_blocks/#{b.id}/edit"
     assert_response :success
@@ -53,6 +54,17 @@ class TextBlocksProjectTest < Redmine::IntegrationTest
     b.reload
     assert_equal 'lorem ipsum', b.text
     assert_equal 'new', b.name
+
+    assert_difference 'TextBlock.count' do
+      post '/projects/ecookbook/text_blocks', params: { text_block: { name: 'test2', text: 'lorem ipsum2'}}
+    end
+    assert_redirected_to '/projects/ecookbook/settings/text_blocks'
+
+    follow_redirect!
+
+    assert b = TextBlock.find_by_name('test2')
+    assert_equal 'lorem ipsum2', b.text
+    assert_equal 2, b.position
 
     assert_difference 'TextBlock.count', -1 do
       delete "/projects/ecookbook/text_blocks/#{b.id}"

--- a/test/integration/text_blocks_project_test.rb
+++ b/test/integration/text_blocks_project_test.rb
@@ -2,7 +2,7 @@ require_relative '../test_helper'
 
 class TextBlocksProjectTest < Redmine::IntegrationTest
   fixtures :users, :email_addresses, :user_preferences,
-    :roles, :projects, :members, :member_roles
+    :roles, :projects, :members, :member_roles, :issue_statuses
 
   def setup
     super
@@ -37,7 +37,9 @@ class TextBlocksProjectTest < Redmine::IntegrationTest
     assert_response :success
 
     assert_difference 'TextBlock.count' do
-      post '/projects/ecookbook/text_blocks', params: { text_block: { name: 'test', text: 'lorem ipsum'}}
+      post '/projects/ecookbook/text_blocks', params: {
+        text_block: { name: 'test', text: 'lorem ipsum', issue_status_ids: [1, 2] }
+      }
     end
     assert_redirected_to '/projects/ecookbook/settings/text_blocks'
 
@@ -45,6 +47,7 @@ class TextBlocksProjectTest < Redmine::IntegrationTest
 
     assert b = TextBlock.find_by_name('test')
     assert_equal 'lorem ipsum', b.text
+    assert_equal [1, 2], b.issue_statuses.map(&:id).sort
     assert_equal 1, b.position
 
     get "/projects/ecookbook/text_blocks/#{b.id}/edit"
@@ -56,7 +59,9 @@ class TextBlocksProjectTest < Redmine::IntegrationTest
     assert_equal 'new', b.name
 
     assert_difference 'TextBlock.count' do
-      post '/projects/ecookbook/text_blocks', params: { text_block: { name: 'test2', text: 'lorem ipsum2'}}
+      post '/projects/ecookbook/text_blocks', params: {
+        text_block: { name: 'test2', text: 'lorem ipsum2', issue_status_ids: [1, 2] }
+      }
     end
     assert_redirected_to '/projects/ecookbook/settings/text_blocks'
 
@@ -64,6 +69,7 @@ class TextBlocksProjectTest < Redmine::IntegrationTest
 
     assert b = TextBlock.find_by_name('test2')
     assert_equal 'lorem ipsum2', b.text
+    assert_equal [1, 2], b.issue_statuses.map(&:id).sort
     assert_equal 2, b.position
 
     assert_difference 'TextBlock.count', -1 do

--- a/test/unit/text_block_test.rb
+++ b/test/unit/text_block_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 class TextBlockTest < ActiveSupport::TestCase
-  fixtures :projects
+  fixtures :projects, :issue_statuses
 
   setup do
     @project = Project.find 'ecookbook'
@@ -52,6 +52,41 @@ class TextBlockTest < ActiveSupport::TestCase
       assert r.text_block_saved?
       assert_equal 'test', r.text_block.name
       assert_equal project, r.text_block.project
+    end
+  end
+
+  test 'should save params in global text block' do
+    assert_difference 'TextBlock.count' do
+      r = RedmineTextBlocks::SaveTextBlock.(
+        {
+          name: 'test',
+          text: 'lorem ipsum',
+          issue_status_ids: [1, 2]
+        }
+      )
+      assert r.text_block_saved?
+      assert_equal 'test', r.text_block.name
+      assert_equal 'lorem ipsum', r.text_block.text
+      assert_equal [1, 2], r.text_block.issue_status_ids.sort
+      assert_equal 1, r.text_block.position
+    end
+  end
+
+  test 'should save params in local text block' do
+    assert_difference 'TextBlock.count' do
+      r = RedmineTextBlocks::SaveTextBlock.(
+        {
+          name: 'test',
+          text: 'lorem ipsum',
+          issue_status_ids: [1, 2]
+        },
+        project: @project
+      )
+      assert r.text_block_saved?
+      assert_equal 'test', r.text_block.name
+      assert_equal 'lorem ipsum', r.text_block.text
+      assert_equal [1, 2], r.text_block.issue_status_ids.sort
+      assert_equal 1, r.text_block.position
     end
   end
 


### PR DESCRIPTION
Fixes #33.

Changes proposed in this pull request:
- Add `position:integer` column to `text_blocks` table
  - Add db/migrate by `bundle exec rails generate redmine_plugin_migration redmine_text_blocks add_position_to_text_blocks position:integer`, then modify `change` method manually.
    - Reference: [Patch #31498: Add redmine_plugin_migration generator - Redmine](https://www.redmine.org/issues/31498)
  - Keeping current order is very important in some case, so execute the following on `rails console` after executing `rake redmine:plugins:migrate`.

      ```rb
      res = TextBlock.connection.select_all("SELECT id, name, project_id, row_number() over(PARTITION by project_id) AS position FROM #{TextBlock.table_name}")
      res.rows.each{|row| TextBlock.connection.execute("UPDATE #{TextBlock.table_name} SET position=#{row[3]} WHERE id=#{row[0]}")}
      ```
      - Reference: [postgresql - SQL update records with ROW_NUMBER() - Stack Overflow](https://stackoverflow.com/questions/41069860/sql-update-records-with-row-number)
    - Adding above to `db/migrate` file seems to be a bit difficult, because `row_number` function seems to be supported on the following condition and checking the condition is too much.
      - PostgreSQL >= 8.4 (https://www.postgresql.org/docs/8.4/functions-window.html)
      - MySQL >= 8.0 (https://www.mysqltutorial.org/mysql-row_number/)
      - SQLite >= 3.25 (https://www.sqlite.org/releaselog/3_25_0.html)
- There are global (admin) and each project level templates, and if both exists, show global => project order.
  - DB default is nulls last, so I set sorted as follows.
    - `order(Arel.sql('project_id IS NOT NULL, project_id ASC, position ASC'))`
    - Reference: [Rails: Order with nulls last - Stack Overflow](https://stackoverflow.com/questions/5826210/rails-order-with-nulls-last)
- Add some tests to cover above changes.

@gtt-project/maintainer
