### PR TITLE
Adds wiki-edit class to form element.

### DIFF
--- a/app/views/text_blocks/_form.html.erb
+++ b/app/views/text_blocks/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="box tabular">
   <p><%= f.text_field :name, required: true, size: 25 %></p>
-  <p><%= f.text_area :text, label: l(:field_text_block_text), rows: 10 %></p>
+  <p><%= f.text_area :text, label: l(:field_text_block_text), rows: 10, class: 'wiki-edit' %></p>
   <p>
     <%= content_tag :label, l(:label_issue_status_plural) %>
     <%= f.collection_select :issue_status_ids,


### PR DESCRIPTION
Fixes #35 .

Changes proposed in this pull request:
- Adds the class `wiki-edit` to textarea form element, which should solve the issue with wikitoolbar returning "undefined"

Note: this fix wrked for me in another plugin, so if you have a chance please test it once in a different setup.

@gtt-project/maintainer
