### PR TITLE
Adjust CI with redmine master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,14 +67,14 @@ jobs:
 
     steps:
       - name: Checkout Redmine
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: redmine/redmine
           ref: ${{ matrix.redmine_version }}
           path: redmine
 
       - name: Checkout Plugin
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ on:
   push:
     branches:
       - main
-      - master
+      - next
   pull_request:
     branches:
       - main
-      - master
+      - next
 
 jobs:
   test:
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: [4.2-stable, 5.0-stable, master]
-        ruby_version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        redmine_version: [4.2-stable, 5.0-stable, 5.1-stable, master]
+        ruby_version: ['2.7', '3.0', '3.1', '3.2']
         db: [mysql, postgres, sqlite]
         # # System test takes 2~3 times longer, so limit to specific matrix combinations
         # # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
@@ -43,8 +43,6 @@ jobs:
             ruby_version: '3.2'
           - redmine_version: 5.0-stable
             ruby_version: '3.2'
-          - redmine_version: master
-            ruby_version: '2.6'
 
     services:
       mysql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
             ruby_version: '3.2'
           - redmine_version: 5.0-stable
             ruby_version: '3.2'
+          - redmine_version: master
+            ruby_version: '2.7'
 
     services:
       mysql:

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -1,4 +1,4 @@
-class TextBlock < ActiveRecord::Base
+class TextBlock < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   belongs_to :project
   has_and_belongs_to_many :issue_statuses
   acts_as_positioned :scope => [:project_id]


### PR DESCRIPTION
Changes proposed in this pull request:
- Set `main` and `next` branches as targets.
- Add `5.1-stable` to redmine version
- Drop `2.6` from ruby version
- Support redmine `master` branch with the following workaround.
  - Link: https://github.com/agileware-jp/redmine_issue_templates/issues/95
- Update `actions/checkout@v4` to use Node.js 20

Redmine official version matrix is here:
https://www.redmine.org/projects/redmine/wiki/RedmineInstall

@gtt-project/maintainer
