### PR TITLE
Replace removed jQuery api '.size()' to '.length'

### DIFF
--- a/assets/javascripts/text_blocks.js
+++ b/assets/javascripts/text_blocks.js
@@ -36,7 +36,7 @@ var TextBlocks = {
 
   reload: function(e){
     var projectId = null
-    if ($("#issue_project_id").size() > 0) {
+    if ($("#issue_project_id").length > 0) {
       projectId = $("#issue_project_id").val()
     } else {
       projectId = $("#text_block_project_id").val()


### PR DESCRIPTION
Fixes removed deprecated jQuery API (`.size()`) error after Redmine 5.0.
* [Feature #34337: Remove jQuery Migrate - Redmine](https://www.redmine.org/issues/34337)

Changes proposed in this pull request:
- Replace removed jQuery API '.size()` to `.length`.

@dkastl @mopinfish 
This is equivalent with the following Supply plugin's PR.
https://github.com/gtt-project/redmine_supply/pull/25 