### PR TITLE
Drop Redmine 5.0 and adjust CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     container:
-      image: ruby:${{ matrix.ruby_version }}-bullseye
+      image: ruby:${{ matrix.ruby_version }}-bookworm
 
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: [5.0-stable, 5.1-stable, 6.0-stable, master]
+        redmine_version: [5.1-stable, 6.0-stable, master]
         ruby_version: ['3.1', '3.2', '3.3']
         db: [mysql, postgres, sqlite]
         # # System test takes 2~3 times longer, so limit to specific matrix combinations
@@ -35,24 +35,21 @@ jobs:
         #     ruby_version: '3.3'
         #     db: mysql
         exclude:
-          - redmine_version: 5.0-stable
-            ruby_version: '3.2'
-          - redmine_version: 5.0-stable
-            ruby_version: '3.3'
           - redmine_version: 5.1-stable
             ruby_version: '3.3'
-
+          - redmine_version: master
+            ruby_version: '3.1'
     services:
       mysql:
-        image: mysql:5.7 # min
-        # image: mysql:9.1 # latest
+        image: mysql:8.0 # min
+        # image: mysql:9.3 # latest
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:
           - 3306:3306
         options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
       postgres:
-        image: postgres:10 # min
+        image: postgres:14 # min
         # image: postgres:17 # latest
         env:
           POSTGRES_USER: postgres

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Redmine Text Blocks Plugin
 
-[![CI](https://github.com/gtt-project/redmine_text_blocks/workflows/Test%20with%20Postgres/badge.svg)](https://github.com/gtt-project/redmine_text_blocks/actions?query=workflow%3A%22Test%20with%20Postgres%22+branch%3Amain)
-[![CI](https://github.com/gtt-project/redmine_text_blocks/workflows/Test%20with%20MySQL/badge.svg)](https://github.com/gtt-project/redmine_text_blocks/actions?query=workflow%3A%22Test%20with%20MySQL%22+branch%3Amain)
-[![CI](https://github.com/gtt-project/redmine_text_blocks/workflows/Test%20with%20SQLite/badge.svg)](https://github.com/gtt-project/redmine_text_blocks/actions?query=workflow%3A%22Test%20with%20SQLite%22+branch%3Amain)
+[![CI](https://github.com/gtt-project/redmine_text_blocks/workflows/Test/badge.svg)](https://github.com/gtt-project/redmine_text_blocks/actions?query=workflow%3ATest+branch%3Amain)
 
 This plugin adds configurable text blocks for replying to issues.
 
 ## Requirements
 
-- Redmine >= 5.0.0
+- Redmine >= 5.1.0
 
 ## Installation
 

--- a/init.rb
+++ b/init.rb
@@ -6,9 +6,9 @@ Redmine::Plugin.register :redmine_text_blocks do
   author_url 'https://github.com/georepublic'
   url 'https://github.com/gtt-project/redmine_text_blocks'
   description 'Adds configurable text blocks for replying to issues'
-  version '3.0.0'
+  version '3.1.0'
 
-  requires_redmine version_or_higher: '5.0.0'
+  requires_redmine version_or_higher: '5.1.0'
 
   #settings default: {
   #}, partial: 'redmine_text_blocks/settings'


### PR DESCRIPTION
Changes proposed in this pull request:
- Drop Redmine 5.0 support
  - Update `init.rb` minor version
- Adjust CI matrix and image versions
- Fix `README.md` CI badge's broken images and links
  - Before fix:
    - ![redmine_text_blocks-README-md-badges-broken](https://github.com/user-attachments/assets/172adfc7-4941-442f-9fd8-e3f5e3f818d6)
  - After fix:
    - ![redmine_text_blocks-README-md-badges-passing](https://github.com/user-attachments/assets/5ed64636-d8b0-4a05-ad16-31f698e1ec92)

@gtt-project/maintainer
