### PR TITLE
Fix project settings text blocks SVG icon

### DIFF
--- a/app/views/projects/settings/_text_blocks.html.erb
+++ b/app/views/projects/settings/_text_blocks.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= link_to l(:label_text_block_new), new_project_text_block_path(@project), class: 'icon icon-add' %>
+  <%= link_to (Redmine::VERSION.to_s >= '6.0.0') ? sprite_icon('add', l(:label_text_block_new)) : l(:label_text_block_new), new_project_text_block_path(@project), class: 'icon icon-add' %>
 </p>
 
 <%= render partial: 'text_blocks/list', locals: { text_blocks: TextBlock.where(project_id: @project.id).sorted } %>


### PR DESCRIPTION
Fixes #43.

Changes proposed in this pull request:
- Fix project settings text blocks SVG icon
  - Redmine `6.0-stable` branch:
    - ![6 0-stable-branch-project-settings-text-blocks-icon](https://github.com/user-attachments/assets/90e044c7-3e7e-43d3-9218-59c450088eca)
  - Redmine `5.1-stable` branch:
    - ![5 1-stable-branch-project-settings-text-blocks-icon](https://github.com/user-attachments/assets/19f77dbe-ee83-4537-8ed7-c8282e8b47f1)

@gtt-project/maintainer
